### PR TITLE
Added configuration support to the request macros, commands, and blade directives

### DIFF
--- a/src/config/config.php
+++ b/src/config/config.php
@@ -1,8 +1,9 @@
 <?php
 declare(strict_types=1);
 
-return [
+use Longman\LaravelLodash\Commands;
 
+return [
     'debug' => [
         'ips' => [ // IP list for enabling debug mode
             //'127.0.0.1',
@@ -38,4 +39,25 @@ return [
         'x_xss_protection'       => '1; mode=block', // X-XSS-Protection header value
     ],
 
+    'register_blade_directives' => [
+        'datetime' => true,
+        'plural'   => true,
+    ],
+
+    'register_request_macros' => [
+        'getInt'    => true,
+        'getBool'   => true,
+        'getFloat'  => true,
+        'getString' => true,
+    ],
+
+    'available_commands' => [
+        'command.lodash.clear-all'     => Commands\ClearAll::class,
+        'command.lodash.db.clear'      => Commands\DbClear::class,
+        'command.lodash.db.dump'       => Commands\DbDump::class,
+        'command.lodash.db.restore'    => Commands\DbRestore::class,
+        'command.lodash.log.clear'     => Commands\LogClear::class,
+        'command.lodash.user.add'      => Commands\UserAdd::class,
+        'command.lodash.user.password' => Commands\UserPassword::class,
+    ],
 ];


### PR DESCRIPTION
Sometimes, people do not want to load the macros or some specific command. This allows them to remove a specific command or macro or directive from being registered entirely. This does not break compatibility.