### PR TITLE
Fix incorrect bindings for laravel > 5.6

### DIFF
--- a/src/Lodash/Eloquent/ManyToManyPreload.php
+++ b/src/Lodash/Eloquent/ManyToManyPreload.php
@@ -108,13 +108,12 @@ trait ManyToManyPreload
         $joinRightColumn = $joins[0]->wheres[0]['second'];
         $joinOperator = $joins[0]->wheres[0]['operator'];
 
-        // Remove extra wheres and bindings
+        // Remove extra wheres
         $wheres = $query->getQuery()->wheres;
         $bindings = $query->getQuery()->bindings;
         foreach ($wheres as $key => $where) {
             if (isset($where['column']) && $where['column'] === $queryKeyColumn) {
                 $count = count($where['values']);
-                $bindings['where'] = array_slice($bindings['where'], $count);
                 unset($wheres[$key]);
             }
         }


### PR DESCRIPTION
in laravel <= 5.6 when eager loading Many to Many relationship query had placeholders for related table ids. example:

```
SELECT *
FROM table
WHERE related_id IN (?, ?, ?...)
```

After 5.6 query does not hold placeholders for related ids, instead it looks like:
```
SELECT *
FROM table
WHERE related_id IN (123, 124, 125...)
```

so the removal of extra bindings is unnecessary during loading ManyToManyPreload