### PR TITLE
When emulated user requests new access token, set emulator user id.

### DIFF
--- a/src/Lodash/Auth/Passport/Grants/InternalRefreshTokenGrant.php
+++ b/src/Lodash/Auth/Passport/Grants/InternalRefreshTokenGrant.php
@@ -5,7 +5,6 @@ declare(strict_types=1);
 namespace Longman\LaravelLodash\Auth\Passport\Grants;
 
 use DateInterval;
-use Laravel\Passport\TokenRepository;
 use League\OAuth2\Server\Entities\ClientEntityInterface;
 use League\OAuth2\Server\Exception\OAuthServerException;
 use League\OAuth2\Server\Grant\RefreshTokenGrant;
@@ -15,6 +14,7 @@ use League\OAuth2\Server\RequestEvent;
 use League\OAuth2\Server\RequestRefreshTokenEvent;
 use League\OAuth2\Server\ResponseTypes\ResponseTypeInterface;
 use Longman\LaravelLodash\Auth\Contracts\AuthServiceContract;
+use Longman\LaravelLodash\Auth\Contracts\TokenRepositoryContract;
 use Psr\Http\Message\ServerRequestInterface;
 
 use function implode;
@@ -23,12 +23,12 @@ use function is_null;
 
 class InternalRefreshTokenGrant extends RefreshTokenGrant
 {
-    private readonly TokenRepository $tokenRepository;
+    private readonly TokenRepositoryContract $tokenRepository;
     private readonly AuthServiceContract $authService;
 
     public function __construct(
         RefreshTokenRepositoryInterface $refreshTokenRepository,
-        TokenRepository $tokenRepository,
+        TokenRepositoryContract $tokenRepository,
         AuthServiceContract $authService,
     ) {
         parent::__construct($refreshTokenRepository);

--- a/src/Lodash/Auth/Passport/Grants/InternalRefreshTokenGrant.php
+++ b/src/Lodash/Auth/Passport/Grants/InternalRefreshTokenGrant.php
@@ -90,7 +90,7 @@ class InternalRefreshTokenGrant extends RefreshTokenGrant
             }
         }
 
-        // when emulated user requests mew access token. set emulator user id.
+        // when emulated user requests new access token. set emulator user id.
         $oldAccessToken = $this->tokenRepository->find($oldRefreshToken['access_token_id']);
         if ($oldAccessToken->emulator_user_id) {
             $this->authService->updateAccessToken($accessToken->getIdentifier(), $oldAccessToken->emulator_user_id);

--- a/src/Lodash/Auth/Passport/Grants/InternalRefreshTokenGrant.php
+++ b/src/Lodash/Auth/Passport/Grants/InternalRefreshTokenGrant.php
@@ -8,12 +8,12 @@ use DateInterval;
 use League\OAuth2\Server\Entities\ClientEntityInterface;
 use League\OAuth2\Server\Exception\OAuthServerException;
 use League\OAuth2\Server\Grant\RefreshTokenGrant;
-use League\OAuth2\Server\Repositories\RefreshTokenRepositoryInterface;
 use League\OAuth2\Server\RequestAccessTokenEvent;
 use League\OAuth2\Server\RequestEvent;
 use League\OAuth2\Server\RequestRefreshTokenEvent;
 use League\OAuth2\Server\ResponseTypes\ResponseTypeInterface;
 use Longman\LaravelLodash\Auth\Contracts\AuthServiceContract;
+use Longman\LaravelLodash\Auth\Contracts\RefreshTokenBridgeRepositoryContract;
 use Longman\LaravelLodash\Auth\Contracts\TokenRepositoryContract;
 use Psr\Http\Message\ServerRequestInterface;
 
@@ -27,7 +27,7 @@ class InternalRefreshTokenGrant extends RefreshTokenGrant
     private readonly AuthServiceContract $authService;
 
     public function __construct(
-        RefreshTokenRepositoryInterface $refreshTokenRepository,
+        RefreshTokenBridgeRepositoryContract $refreshTokenRepository,
         TokenRepositoryContract $tokenRepository,
         AuthServiceContract $authService,
     ) {

--- a/src/Lodash/Auth/Passport/Grants/InternalRefreshTokenGrant.php
+++ b/src/Lodash/Auth/Passport/Grants/InternalRefreshTokenGrant.php
@@ -4,19 +4,99 @@ declare(strict_types=1);
 
 namespace Longman\LaravelLodash\Auth\Passport\Grants;
 
+use DateInterval;
+use Laravel\Passport\TokenRepository;
 use League\OAuth2\Server\Entities\ClientEntityInterface;
 use League\OAuth2\Server\Exception\OAuthServerException;
 use League\OAuth2\Server\Grant\RefreshTokenGrant;
+use League\OAuth2\Server\Repositories\RefreshTokenRepositoryInterface;
+use League\OAuth2\Server\RequestAccessTokenEvent;
 use League\OAuth2\Server\RequestEvent;
+use League\OAuth2\Server\RequestRefreshTokenEvent;
+use League\OAuth2\Server\ResponseTypes\ResponseTypeInterface;
+use Longman\LaravelLodash\Auth\Contracts\AuthServiceContract;
 use Psr\Http\Message\ServerRequestInterface;
 
+use function implode;
+use function in_array;
 use function is_null;
 
 class InternalRefreshTokenGrant extends RefreshTokenGrant
 {
+    private readonly TokenRepository $tokenRepository;
+    private readonly AuthServiceContract $authService;
+
+    public function __construct(
+        RefreshTokenRepositoryInterface $refreshTokenRepository,
+        TokenRepository $tokenRepository,
+        AuthServiceContract $authService,
+    ) {
+        parent::__construct($refreshTokenRepository);
+
+        $this->tokenRepository = $tokenRepository;
+        $this->authService = $authService;
+    }
+
     public function getIdentifier(): string
     {
         return 'internal_refresh_token';
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function respondToAccessTokenRequest(
+        ServerRequestInterface $request,
+        ResponseTypeInterface $responseType,
+        DateInterval $accessTokenTTL,
+    ) {
+        // Validate request
+        $client = $this->validateClient($request);
+        $oldRefreshToken = $this->validateOldRefreshToken($request, $client->getIdentifier());
+        $scopes = $this->validateScopes(
+            $this->getRequestParameter(
+                'scope',
+                $request,
+                implode(self::SCOPE_DELIMITER_STRING, $oldRefreshToken['scopes']),
+            ),
+        );
+
+        // The OAuth spec says that a refreshed access token can have the original scopes or fewer so ensure
+        // the request doesn't include any new scopes
+        foreach ($scopes as $scope) {
+            if (in_array($scope->getIdentifier(), $oldRefreshToken['scopes'], true) === false) {
+                throw OAuthServerException::invalidScope($scope->getIdentifier());
+            }
+        }
+
+        // Expire old tokens
+        $this->accessTokenRepository->revokeAccessToken($oldRefreshToken['access_token_id']);
+        if ($this->revokeRefreshTokens) {
+            $this->refreshTokenRepository->revokeRefreshToken($oldRefreshToken['refresh_token_id']);
+        }
+
+        // Issue and persist new access token
+        $accessToken = $this->issueAccessToken($accessTokenTTL, $client, $oldRefreshToken['user_id'], $scopes);
+        $this->getEmitter()->emit(new RequestAccessTokenEvent(RequestEvent::ACCESS_TOKEN_ISSUED, $request, $accessToken));
+        $responseType->setAccessToken($accessToken);
+
+        // Issue and persist new refresh token if given
+        if ($this->revokeRefreshTokens) {
+            $refreshToken = $this->issueRefreshToken($accessToken);
+
+            if ($refreshToken !== null) {
+                $this->getEmitter()->emit(new RequestRefreshTokenEvent(RequestEvent::REFRESH_TOKEN_ISSUED, $request, $refreshToken));
+                $responseType->setRefreshToken($refreshToken);
+            }
+        }
+
+        // when emulated user requests mew access token. set emulator user id.
+        $oldAccessToken = $this->tokenRepository->find($oldRefreshToken['access_token_id']);
+        if ($oldAccessToken->emulator_user_id) {
+            $this->authService->updateAccessToken($accessToken->getIdentifier(), $oldAccessToken->emulator_user_id);
+        }
+
+        return $responseType;
     }
 
     protected function validateClient(ServerRequestInterface $request): ClientEntityInterface

--- a/src/Lodash/Auth/Passport/PassportServiceProvider.php
+++ b/src/Lodash/Auth/Passport/PassportServiceProvider.php
@@ -9,6 +9,7 @@ use Illuminate\Http\Request;
 use Laravel\Passport\Passport;
 use Laravel\Passport\PassportServiceProvider as BasePassportServiceProvider;
 use Laravel\Passport\PassportUserProvider;
+use Laravel\Passport\TokenRepository as PassportTokenRepository;
 use League\OAuth2\Server\AuthorizationServer;
 use League\OAuth2\Server\ResourceServer;
 use Longman\LaravelLodash\Auth\Contracts\AuthServiceContract;
@@ -104,9 +105,11 @@ class PassportServiceProvider extends BasePassportServiceProvider
 
     protected function makeInternalRefreshTokenGrant(): InternalRefreshTokenGrant
     {
-        $repository = $this->app->make(RefreshTokenBridgeRepositoryContract::class);
-
-        $grant = new InternalRefreshTokenGrant($repository);
+        $grant = new InternalRefreshTokenGrant(
+            $this->app->make(RefreshTokenBridgeRepositoryContract::class),
+            $this->app->make(PassportTokenRepository::class),
+            $this->app->make(AuthServiceContract::class),
+        );
 
         $grant->setRefreshTokenTTL(new DateInterval('P1Y'));
 

--- a/src/Lodash/Auth/Passport/PassportServiceProvider.php
+++ b/src/Lodash/Auth/Passport/PassportServiceProvider.php
@@ -9,7 +9,6 @@ use Illuminate\Http\Request;
 use Laravel\Passport\Passport;
 use Laravel\Passport\PassportServiceProvider as BasePassportServiceProvider;
 use Laravel\Passport\PassportUserProvider;
-use Laravel\Passport\TokenRepository as PassportTokenRepository;
 use League\OAuth2\Server\AuthorizationServer;
 use League\OAuth2\Server\ResourceServer;
 use Longman\LaravelLodash\Auth\Contracts\AuthServiceContract;
@@ -107,7 +106,7 @@ class PassportServiceProvider extends BasePassportServiceProvider
     {
         $grant = new InternalRefreshTokenGrant(
             $this->app->make(RefreshTokenBridgeRepositoryContract::class),
-            $this->app->make(PassportTokenRepository::class),
+            $this->app->make(TokenRepositoryContract::class),
             $this->app->make(AuthServiceContract::class),
         );
 


### PR DESCRIPTION
If emulated user's access token is expired and new token is generated via refresh token, use `InternalRefreshTokenGrant::respondToAccessTokenRequest()` method instead of `RefreshTokenGrant::respondToAccessTokenRequest` and specifically check if old token had emulator_user_id. If so, set it to the new token as well. 